### PR TITLE
[codex] Block Mintlify assets in robots

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /cdn-cgi/
+Allow: /_next/image
+Disallow: /_next/
+Disallow: /mintlify-assets/
+
+Sitemap: https://docs.hifi.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Add a custom root robots.txt for the Mintlify docs site.
- Preserve the current generated crawl rules while disallowing /mintlify-assets/.

## Why
/mintlify-assets/ contains framework CSS files and favicon configs that should not be crawlable. Mintlify supports custom root robots.txt files, so this avoids needing a support request for path-level headers.

## Validation
- Confirmed the live generated robots.txt rules before copying them into the custom file.
- Reviewed the staged diff to ensure only robots.txt is included.