### PR TITLE
[codex] Scrub ToS session token example

### DIFF
--- a/users/tos.mdx
+++ b/users/tos.mdx
@@ -191,7 +191,7 @@ Display ToS acceptance inline within your application. Best for embedded experie
 
     ```json
     {
-      "url": "https://app.hifi.com/accept-terms-of-service?sessionToken=e12d9c3f-75a8-4bd1-aa3d-97a2cfaf2c40&redirectUrl=https://yourapp.com/onboarding/complete",
+      "url": "https://app.hifi.com/accept-terms-of-service?sessionToken=SESSION_TOKEN&redirectUrl=https://yourapp.com/onboarding/complete",
       "signedAgreementId": "a4f8b3c2-1d5e-4a7b-9c8d-3e2f1a0b9c8d"
     }
     ```


### PR DESCRIPTION
## What changed

Replaces the public ToS response example's literal `sessionToken` value with a `SESSION_TOKEN` placeholder.

## Why

A dashboard ToS URL containing a token-shaped value was appearing in the public Google index via the docs page. Even if the value is only fixture data, examples should not publish token-bearing URLs that look reusable.

Related tracking issue: https://github.com/Hifi-Bridge/docs/issues/76

## Validation

- Confirmed the exact indexed token strings no longer appear in local `/Users/hifi/sites` search results after the docs/API scrub.
- This docs PR only changes the MDX example line.
