### PR TITLE
[codex] Remove crawlable dashboard flow URLs

### DIFF
--- a/api/authentication.mdx
+++ b/api/authentication.mdx
@@ -30,7 +30,6 @@ HIFI provides two environments for development and production:
 
 1. Log in to the [HIFI Dashboard](https://app.hifi.com)
 2. Navigate to **Developer** → **API Keys**  
-   Or go directly to: [app.hifi.com/developer/apiKeys](https://app.hifi.com/developer/apiKeys)
 
 ### Select Your Environment
 

--- a/features/kyc-links.mdx
+++ b/features/kyc-links.mdx
@@ -106,7 +106,7 @@ curl -X POST "https://sandbox.hifibridge.com/v2/kyc-link" \
 
 ```json
 {
-  "kycLinkUrl": "http://app.hifi.com/production/kyc-link?sessionToken=768fb84ad65284cb5fffda212f5e779829318acwdab5a36efbf83c4f44369c73"
+  "kycLinkUrl": "KYC_LINK_URL"
 }
 ```
 

--- a/guides/global-transfers.mdx
+++ b/guides/global-transfers.mdx
@@ -97,7 +97,7 @@ curl --request POST \
 
 ```json
 {
-  "url": "https://app.hifi.com/accept-terms-of-service?sessionToken=a29d65a3...",
+  "url": "TERMS_OF_SERVICE_URL",
   "signedAgreementId": "96bc39ba-c6c6-412a-9452-e95a35d3f533"
 }
 ```

--- a/guides/quickstart.mdx
+++ b/guides/quickstart.mdx
@@ -89,7 +89,7 @@ curl --request POST \
 
 ```json
 {
-  "url": "https://app.hifi.com/accept-terms-of-service?sessionToken=536bb03a...",
+  "url": "TERMS_OF_SERVICE_URL",
   "signedAgreementId": "8cb49537-bcf9-41b1-8d8c-c9c200d7341b"
 }
 ```
@@ -249,7 +249,7 @@ curl --request POST \
 
 ```json
 {
-  "kycLinkUrl": "https://app.hifi.com/sandbox/kyc-link?sessionToken=768fb84ad65284cb5fffda212f5e779829318acwdab5a36efbf83c4f44369c73"
+  "kycLinkUrl": "KYC_LINK_URL"
 }
 ```
 

--- a/guides/remittances.mdx
+++ b/guides/remittances.mdx
@@ -148,7 +148,7 @@ curl --request POST \
 ```json
 {
   "signedAgreementId": "c9c91801-d3a2-4a1c-aa2e-fcb2c473198c",
-  "url": "https://app.hifi.com/accept-terms-of-service?sessionToken=536bb03a..."
+  "url": "TERMS_OF_SERVICE_URL"
 }
 ```
 

--- a/users/tos.mdx
+++ b/users/tos.mdx
@@ -191,7 +191,7 @@ Display ToS acceptance inline within your application. Best for embedded experie
 
     ```json
     {
-      "url": "https://app.hifi.com/accept-terms-of-service?sessionToken=SESSION_TOKEN&redirectUrl=https://yourapp.com/onboarding/complete",
+      "url": "TERMS_OF_SERVICE_URL",
       "signedAgreementId": "a4f8b3c2-1d5e-4a7b-9c8d-3e2f1a0b9c8d"
     }
     ```


### PR DESCRIPTION
## Summary
- Remove the direct dashboard API keys deep link from authentication docs.
- Replace generated Terms of Service and KYC hosted-flow URLs with placeholders in response examples.

## Why
Concrete hosted-flow URLs with session tokens and dashboard deep links can be discovered as crawlable external URLs, creating SEO noise. The examples still describe the response shape without exposing crawlable generated links.

## Validation
- Searched the docs tree for `dashboard.hifi.com`, `developer/apiKeys`, `accept-terms-of-service`, `favicon.ico`, `sessionToken=`, and `kyc-link?`; no matches remain.
- Reviewed the staged diff to confirm only docs examples changed.