### PR TITLE
[codex] Update EUR and HKD currency docs

### DIFF
--- a/coverage.mdx
+++ b/coverage.mdx
@@ -51,65 +51,105 @@ description: "HIFI enables inflows and outflows across multiple regions. Here ar
 
 | Country              | Currency | Direction | Payment Methods   |
 | -------------------- | -------- | --------- | ----------------- |
+| Albania              | EUR      | Payout    | SEPA              |
+| Andorra              | EUR      | Payout    | SEPA              |
 | Argentina            | USD      | Payout    | SWIFT             |
 | Australia            | USD      | Payout    | SWIFT             |
+| Austria              | EUR      | Payout    | SEPA              |
 | Austria              | USD      | Payout    | SWIFT             |
+| Belgium              | EUR      | Payout    | SEPA              |
 | Belgium              | USD      | Payout    | SWIFT             |
 | Brazil               | BRL      | Payout    | PIX               |
 | Brazil               | USD      | Payout    | SWIFT             |
+| Bulgaria             | EUR      | Payout    | SEPA              |
 | Bulgaria             | USD      | Payout    | SWIFT             |
 | Chile                | USD      | Payout    | SWIFT             |
 | China                | CNY      | Payout    | SWIFT             |
 | China                | USD      | Payout    | SWIFT             |
 | Colombia             | USD      | Payout    | SWIFT             |
+| Croatia              | EUR      | Payout    | SEPA              |
 | Croatia              | USD      | Payout    | SWIFT             |
+| Cyprus               | EUR      | Payout    | SEPA              |
 | Cyprus               | USD      | Payout    | SWIFT             |
+| Czech Republic       | EUR      | Payout    | SEPA              |
 | Czech Republic       | USD      | Payout    | SWIFT             |
+| Denmark              | EUR      | Payout    | SEPA              |
 | Denmark              | USD      | Payout    | SWIFT             |
+| Estonia              | EUR      | Payout    | SEPA              |
 | Estonia              | USD      | Payout    | SWIFT             |
+| Finland              | EUR      | Payout    | SEPA              |
 | Finland              | USD      | Payout    | SWIFT             |
+| France               | EUR      | Payout    | SEPA              |
 | France               | USD      | Payout    | SWIFT             |
+| Germany              | EUR      | Payout    | SEPA              |
 | Germany              | USD      | Payout    | SWIFT             |
+| Greece               | EUR      | Payout    | SEPA              |
 | Greece               | USD      | Payout    | SWIFT             |
 | Hong Kong            | HKD      | Payout    | SWIFT, CHATS, FPS |
 | Hong Kong            | USD      | Payout    | SWIFT             |
+| Hungary              | EUR      | Payout    | SEPA              |
 | Hungary              | USD      | Payout    | SWIFT             |
+| Iceland              | EUR      | Payout    | SEPA              |
 | Iceland              | USD      | Payout    | SWIFT             |
 | Indonesia            | USD      | Payout    | SWIFT             |
+| Ireland              | EUR      | Payout    | SEPA              |
 | Ireland              | USD      | Payout    | SWIFT             |
 | Israel               | USD      | Payout    | SWIFT             |
+| Italy                | EUR      | Payout    | SEPA              |
 | Italy                | USD      | Payout    | SWIFT             |
 | Japan                | USD      | Payout    | SWIFT             |
 | Kenya                | USD      | Payout    | SWIFT             |
+| Latvia               | EUR      | Payout    | SEPA              |
 | Latvia               | USD      | Payout    | SWIFT             |
+| Liechtenstein        | EUR      | Payout    | SEPA              |
 | Liechtenstein        | USD      | Payout    | SWIFT             |
+| Lithuania            | EUR      | Payout    | SEPA              |
 | Lithuania            | USD      | Payout    | SWIFT             |
+| Luxembourg           | EUR      | Payout    | SEPA              |
 | Luxembourg           | USD      | Payout    | SWIFT             |
+| Malta                | EUR      | Payout    | SEPA              |
 | Malta                | USD      | Payout    | SWIFT             |
 | Mexico               | MXN      | Payout    | SPEI              |
 | Mexico               | USD      | Payout    | SWIFT             |
+| Moldova              | EUR      | Payout    | SEPA              |
+| Monaco               | EUR      | Payout    | SEPA              |
+| Montenegro           | EUR      | Payout    | SEPA              |
+| Netherlands          | EUR      | Payout    | SEPA              |
 | Netherlands          | USD      | Payout    | SWIFT             |
 | New Zealand          | USD      | Payout    | SWIFT             |
 | Nigeria              | USD      | Payout    | SWIFT             |
 | Nigeria              | NGN      | Payout    | Bank              |
+| North Macedonia      | EUR      | Payout    | SEPA              |
+| Norway               | EUR      | Payout    | SEPA              |
 | Norway               | USD      | Payout    | SWIFT             |
+| Poland               | EUR      | Payout    | SEPA              |
 | Poland               | USD      | Payout    | SWIFT             |
+| Portugal             | EUR      | Payout    | SEPA              |
 | Portugal             | USD      | Payout    | SWIFT             |
+| Romania              | EUR      | Payout    | SEPA              |
 | Romania              | USD      | Payout    | SWIFT             |
+| San Marino           | EUR      | Payout    | SEPA              |
+| Serbia               | EUR      | Payout    | SEPA              |
 | Serbia               | USD      | Payout    | SWIFT             |
 | Singapore            | SGD      | Payout    | Local             |
 | Singapore            | USD      | Payout    | SWIFT             |
+| Slovakia             | EUR      | Payout    | SEPA              |
 | Slovakia             | USD      | Payout    | SWIFT             |
+| Slovenia             | EUR      | Payout    | SEPA              |
 | Slovenia             | USD      | Payout    | SWIFT             |
 | South Africa         | USD      | Payout    | SWIFT             |
 | South Korea          | USD      | Payout    | SWIFT             |
+| Spain                | EUR      | Payout    | SEPA              |
 | Spain                | USD      | Payout    | SWIFT             |
+| Sweden               | EUR      | Payout    | SEPA              |
 | Sweden               | USD      | Payout    | SWIFT             |
+| Switzerland          | EUR      | Payout    | SEPA              |
 | Taiwan               | USD      | Payout    | SWIFT             |
 | Thailand             | USD      | Payout    | SWIFT             |
 | Turkey               | USD      | Payout    | SWIFT             |
 | United Arab Emirates | USD      | Payout    | SWIFT             |
 | United Kingdom       | USD      | Payout    | SWIFT             |
+| Vatican City         | EUR      | Payout    | SEPA              |
 
 [Learn more about the Global Network Rail](/rails/global-network)
 

--- a/rails.mdx
+++ b/rails.mdx
@@ -37,12 +37,13 @@ Learn more: [USD Rail](/docs/rails/usd)
 
 ## Global Network Rail
 
-The Global Network Rail enables payouts to Asia and Africa with support for multiple currencies.
+The Global Network Rail enables payouts across Asia, Europe, Africa, and the Americas with support for multiple currencies.
 
 **Supported Regions:**
 
 - **China (CN)**: USD and CNY
 - **Hong Kong (HK)**: USD and HKD
+- **Europe**: EUR and USD
 - **Other regions**: BRL, MXN, NGN
 
 Learn more: [Global Network Rail](/docs/rails/global-network)

--- a/rails/global-network.mdx
+++ b/rails/global-network.mdx
@@ -14,8 +14,8 @@ description: "The Global Network Rail enables payouts across multiple regions wi
 | FPS            | Payout    | Real Time         |
 | SPEI           | Payout    | Real Time         |
 | PIX            | Payout    | Real Time         |
-| SEPA (under 100k) | Payout    | Instant or minutes |
-| SEPA (over 100k)  | Payout    | Next business day |
+| SEPA (< $100k) | Payout    | Instant or minutes |
+| SEPA (> $100k) | Payout    | Next business day |
 | Bank           | Payout    | 1-3 business days |
 
 <Info>

--- a/rails/global-network.mdx
+++ b/rails/global-network.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Global Network Rail"
 sidebarTitle: "Global Network"
-description: "The Global Network Rail enables payouts to Asia and Africa with support for multiple currencies."
+description: "The Global Network Rail enables payouts across multiple regions with support for multiple currencies."
 ---
 
 
@@ -14,6 +14,7 @@ description: "The Global Network Rail enables payouts to Asia and Africa with su
 | FPS            | Payout    | Real Time         |
 | SPEI           | Payout    | Real Time         |
 | PIX            | Payout    | Real Time         |
+| SEPA           | Payout    | 1-2 business days |
 | Bank           | Payout    | 1-3 business days |
 
 <Info>
@@ -28,55 +29,64 @@ description: "The Global Network Rail enables payouts to Asia and Africa with su
 
 | Country              | Currency | Direction |
 | :------------------- | :------- | :-------- |
+| Albania              | EUR      | Payout    |
+| Andorra              | EUR      | Payout    |
 | Argentina            | USD      | Payout    |
-| Austria              | USD      | Payout    |
-| Belgium              | USD      | Payout    |
+| Austria              | USD, EUR | Payout    |
+| Belgium              | USD, EUR | Payout    |
 | Brazil               | USD, BRL | Payout    |
-| Bulgaria             | USD      | Payout    |
+| Bulgaria             | USD, EUR | Payout    |
 | Chile                | USD      | Payout    |
 | China                | USD, CNY | Payout    |
 | Colombia             | USD      | Payout    |
-| Croatia              | USD      | Payout    |
-| Cyprus               | USD      | Payout    |
-| Czech Republic       | USD      | Payout    |
-| Denmark              | USD      | Payout    |
-| Estonia              | USD      | Payout    |
-| Finland              | USD      | Payout    |
-| France               | USD      | Payout    |
-| Germany              | USD      | Payout    |
-| Greece               | USD      | Payout    |
+| Croatia              | USD, EUR | Payout    |
+| Cyprus               | USD, EUR | Payout    |
+| Czech Republic       | USD, EUR | Payout    |
+| Denmark              | USD, EUR | Payout    |
+| Estonia              | USD, EUR | Payout    |
+| Finland              | USD, EUR | Payout    |
+| France               | USD, EUR | Payout    |
+| Germany              | USD, EUR | Payout    |
+| Greece               | USD, EUR | Payout    |
 | Hong Kong            | USD, HKD | Payout    |
-| Hungary              | USD      | Payout    |
-| Iceland              | USD      | Payout    |
+| Hungary              | USD, EUR | Payout    |
+| Iceland              | USD, EUR | Payout    |
 | Indonesia            | USD      | Payout    |
-| Ireland              | USD      | Payout    |
-| Italy                | USD      | Payout    |
+| Ireland              | USD, EUR | Payout    |
+| Italy                | USD, EUR | Payout    |
 | Japan                | USD      | Payout    |
 | Kenya                | USD      | Payout    |
-| Latvia               | USD      | Payout    |
-| Liechtenstein        | USD      | Payout    |
-| Lithuania            | USD      | Payout    |
-| Luxembourg           | USD      | Payout    |
-| Malta                | USD      | Payout    |
+| Latvia               | USD, EUR | Payout    |
+| Liechtenstein        | USD, EUR | Payout    |
+| Lithuania            | USD, EUR | Payout    |
+| Luxembourg           | USD, EUR | Payout    |
+| Malta                | USD, EUR | Payout    |
 | Mexico               | MXN      | Payout    |
-| Netherlands          | USD      | Payout    |
+| Moldova              | EUR      | Payout    |
+| Monaco               | EUR      | Payout    |
+| Montenegro           | EUR      | Payout    |
+| Netherlands          | USD, EUR | Payout    |
 | Nigeria              | NGN      | Payout    |
-| Norway               | USD      | Payout    |
-| Poland               | USD      | Payout    |
-| Portugal             | USD      | Payout    |
-| Romania              | USD      | Payout    |
-| Serbia               | USD      | Payout    |
+| North Macedonia      | EUR      | Payout    |
+| Norway               | USD, EUR | Payout    |
+| Poland               | USD, EUR | Payout    |
+| Portugal             | USD, EUR | Payout    |
+| Romania              | USD, EUR | Payout    |
+| San Marino           | EUR      | Payout    |
+| Serbia               | USD, EUR | Payout    |
 | Singapore            | USD, SGD | Payout    |
-| Slovakia             | USD      | Payout    |
-| Slovenia             | USD      | Payout    |
+| Slovakia             | USD, EUR | Payout    |
+| Slovenia             | USD, EUR | Payout    |
 | South Africa         | USD      | Payout    |
 | South Korea          | USD      | Payout    |
-| Spain                | USD      | Payout    |
-| Sweden               | USD      | Payout    |
+| Spain                | USD, EUR | Payout    |
+| Sweden               | USD, EUR | Payout    |
+| Switzerland          | EUR      | Payout    |
 | Taiwan               | USD      | Payout    |
 | Thailand             | USD      | Payout    |
 | United Arab Emirates | USD      | Payout    |
 | United Kingdom       | USD      | Payout    |
+| Vatican City         | EUR      | Payout    |
 
 ## Individual
 

--- a/rails/global-network.mdx
+++ b/rails/global-network.mdx
@@ -14,7 +14,8 @@ description: "The Global Network Rail enables payouts across multiple regions wi
 | FPS            | Payout    | Real Time         |
 | SPEI           | Payout    | Real Time         |
 | PIX            | Payout    | Real Time         |
-| SEPA           | Payout    | 1-2 business days |
+| SEPA (under 100k) | Payout    | Instant or minutes |
+| SEPA (over 100k)  | Payout    | Next business day |
 | Bank           | Payout    | 1-3 business days |
 
 <Info>

--- a/references/currencies.mdx
+++ b/references/currencies.mdx
@@ -66,6 +66,16 @@ description: "With HIFI, you can convert fiat currencies into stablecoins and vi
 
 <Info>SWIFT and RTP are in development.</Info>
 
+### Europe
+
+<Card>
+
+| Currency | Region         | Payment Method |
+| -------- | -------------- | -------------- |
+| 🇪🇺 EUR   | SEPA countries | SEPA           |
+
+</Card>
+
 ### Africa (Beta)
 
 <Card>
@@ -91,11 +101,11 @@ description: "With HIFI, you can convert fiat currencies into stablecoins and vi
 
 <Card>
 
-| Currency | Country   | Payment Method |
-| -------- | --------- | -------------- |
-| 🇭🇰 USD   | Hong Kong | SWIFT          |
-| 🇭🇰 HKD   | Hong Kong | SWIFT          |
-| 🇨🇳 USD   | China     | SWIFT          |
-| 🇨🇳 CNY   | China     | SWIFT          |
+| Currency | Country   | Payment Method    |
+| -------- | --------- | ----------------- |
+| 🇭🇰 USD   | Hong Kong | SWIFT             |
+| 🇭🇰 HKD   | Hong Kong | SWIFT, CHATS, FPS |
+| 🇨🇳 USD   | China     | SWIFT             |
+| 🇨🇳 CNY   | China     | SWIFT             |
 
 </Card>


### PR DESCRIPTION
## Summary
- Add EUR/SEPA payout support to the Currencies, Coverage, and Global Network Rail docs.
- Update Hong Kong HKD payout methods to include SWIFT, CHATS, and FPS.
- Broaden the Global Network overview language now that EUR/SEPA coverage is included.

## Notes
- Verified against the API repo's `origin/main` Swagger source for account currency support.
- The upstream API spec source still has `CreateEuroOfframp` commented out of `CreateOfframpBody`, and `ToFiatCurrencyParameter` does not yet include `eur`, so generated API Reference pages may still need a source-spec follow-up.

## Validation
- `git diff --check`
