### PR TITLE
updated to valid doc link

### DIFF
--- a/accounts/virtual-accounts.mdx
+++ b/accounts/virtual-accounts.mdx
@@ -516,7 +516,7 @@ curl -X GET "https://sandbox.hifibridge.com/v2/users/usr_abc123/virtual-accounts
 
 ## Sandbox Testing
 
-In sandbox, simulate deposits without real bank transfers using the [Simulate Deposit](https://docs.hifi.com/api-reference/virtual-account/simulate-a-deposit) endpoint.
+In sandbox, simulate deposits without real bank transfers using the [Simulate Deposit](https://docs.hifi.com/api-reference/virtual-account/simulate-a-deposit-to-a-virtual-account) endpoint.
 
 **Request:**
 


### PR DESCRIPTION
At [https://docs.hifi.com/accounts/virtual-accounts](https://docs.hifi.com/accounts/virtual-accounts), under Sandbox Testing section, there's a link to a deprecated doc page so I updated it to point to the intended one.


## 📸 Screenshots / Demo (if applicable)
<img width="1709" height="856" alt="Screenshot 2026-07-21 at 3 56 10 PM" src="https://github.com/user-attachments/assets/e76ca011-b9cb-49d3-94be-cb502607ce22" />
