### PR TITLE
Reorganize coverage by product

### DIFF
--- a/coverage.mdx
+++ b/coverage.mdx
@@ -1,7 +1,27 @@
 ---
 title: "Coverage"
-description: "Explore HIFI's supported payin and payout products by country, currency, and payment method."
+description: "Explore HIFI's supported stablecoins, payin products, and payout products by network, country, currency, and payment method."
 ---
+
+## Stablecoins
+
+HIFI wallets support stablecoins across multiple blockchain networks.
+
+| Network | Stablecoins | Availability |
+| --- | --- | --- |
+| Ethereum | USDC, USDT, USDG, PYUSD | Available |
+| Polygon PoS | USDC, USDT | Available |
+| Solana | USDC, USDT, USDG, PYUSD | Available |
+| Base | USDC | Available |
+| Tron | USDT | Available |
+| Arbitrum | USDC | Upon request |
+| Optimism | USDC | Upon request |
+| Canton | USDCx | Upon request |
+| Flow EVM | PYUSD0 | Upon request |
+| BNB Smart Chain | USDT | Coming soon |
+| XRPL | USDC, RLUSD | Coming soon |
+
+[Learn more about wallets](/wallets)
 
 ## Payins
 

--- a/coverage.mdx
+++ b/coverage.mdx
@@ -1,182 +1,235 @@
 ---
 title: "Coverage"
-description: "HIFI enables inflows and outflows across multiple regions. Here are the countries and currencies we support by rail."
+description: "Explore HIFI's supported payin and payout products by country, currency, and payment method."
 ---
 
-## USD Rail
+## Payins
 
-| Country | Currency | Direction | Payment Methods |
-| --- | --- | --- | --- |
-| United States of America | USD | Payin, Payout | WIRE, ACH, RTP, SWIFT (Payout-only) |
-| Australia | USD | Payout | SWIFT |
-| Austria | USD | Payout | SWIFT |
-| Belgium | USD | Payout | SWIFT |
-| Brazil | USD | Payout | SWIFT |
-| Canada | USD | Payout | SWIFT |
-| Colombia | USD | Payout | SWIFT |
-| Croatia | USD | Payout | SWIFT |
-| Estonia | USD | Payout | SWIFT |
-| Finland | USD | Payout | SWIFT |
-| France | USD | Payout | SWIFT |
-| Germany | USD | Payout | SWIFT |
-| Greece | USD | Payout | SWIFT |
-| Guatemala | USD | Payout | SWIFT |
-| India | USD | Payout | SWIFT |
-| Ireland | USD | Payout | SWIFT |
-| Italy | USD | Payout | SWIFT |
-| Japan | USD | Payout | SWIFT |
-| Lithuania | USD | Payout | SWIFT |
-| Luxembourg | USD | Payout | SWIFT |
-| Malaysia | USD | Payout | SWIFT |
-| Mexico | USD | Payout | SWIFT |
-| Netherlands | USD | Payout | SWIFT |
-| New Zealand | USD | Payout | SWIFT |
-| Norway | USD | Payout | SWIFT |
-| Oman | USD | Payout | SWIFT |
-| Philippines | USD | Payout | SWIFT |
-| Portugal | USD | Payout | SWIFT |
-| Slovenia | USD | Payout | SWIFT |
-| Spain | USD | Payout | SWIFT |
-| Sweden | USD | Payout | SWIFT |
-| United Arab Emirates | USD | Payout | SWIFT |
-| United Kingdom | USD | Payout | SWIFT |
-| Uruguay | USD | Payout | SWIFT |
+### USD Virtual Accounts
+
+USD Virtual Accounts accept recurring deposits through US domestic payment methods and automatically convert the funds to stablecoins.
+
+| Payment Rail | Currency | Typical Duration |
+| --- | --- | --- |
+| ACH | USD | 1-3 business days |
+| Wire | USD | Same day |
+| RTP | USD | Real-time |
+
+[Learn more about USD Virtual Accounts](/accounts/virtual-accounts)
+
+### Africa Payins (Beta)
+
+Africa payins support local-currency deposits through bank transfers and mobile money in select countries.
+
+| Country | Currency | Payment Methods |
+| --- | --- | --- |
+| Benin | XOF | Mobile Money |
+| Botswana | BWP | Bank, Mobile Money |
+| Cameroon | XAF | Mobile Money |
+| Côte d'Ivoire | XOF | Mobile Money |
+| Malawi | MWK | Mobile Money |
+| Nigeria | NGN | Bank Transfer |
+| Tanzania | TZS | Bank, Mobile Money |
+| Togo | XOF | Mobile Money |
+| Uganda | UGX | Mobile Money |
+| Zambia | ZMW | Mobile Money |
+
+[Learn more about the Africa Rail](/rails/africa)
+
+## Payouts
+
+### USD Domestic Payouts
+
+| Payment Rail | Currency | Typical Duration |
+| --- | --- | --- |
+| ACH | USD | 1-3 business days |
+| Wire | USD | \< 1 business day |
+| RTP | USD | Instant |
+
+[Learn more about the USD Rail](/rails/usd)
+
+### USD SWIFT Payouts
+
+Send USD payouts via SWIFT using the USD Rail or Global Network Rail. The table below shows the destinations supported by each network.
+
+| Country | Currency | Network |
+| --- | --- | --- |
+| United States of America | USD | USD Rail |
+| Australia | USD | USD Rail |
+| Austria | USD | USD Rail |
+| Belgium | USD | USD Rail |
+| Brazil | USD | USD Rail |
+| Canada | USD | USD Rail |
+| Colombia | USD | USD Rail |
+| Croatia | USD | USD Rail |
+| Estonia | USD | USD Rail |
+| Finland | USD | USD Rail |
+| France | USD | USD Rail |
+| Germany | USD | USD Rail |
+| Greece | USD | USD Rail |
+| Guatemala | USD | USD Rail |
+| India | USD | USD Rail |
+| Ireland | USD | USD Rail |
+| Italy | USD | USD Rail |
+| Japan | USD | USD Rail |
+| Lithuania | USD | USD Rail |
+| Luxembourg | USD | USD Rail |
+| Malaysia | USD | USD Rail |
+| Mexico | USD | USD Rail |
+| Netherlands | USD | USD Rail |
+| New Zealand | USD | USD Rail |
+| Norway | USD | USD Rail |
+| Oman | USD | USD Rail |
+| Philippines | USD | USD Rail |
+| Portugal | USD | USD Rail |
+| Slovenia | USD | USD Rail |
+| Spain | USD | USD Rail |
+| Sweden | USD | USD Rail |
+| United Arab Emirates | USD | USD Rail |
+| United Kingdom | USD | USD Rail |
+| Uruguay | USD | USD Rail |
+| Argentina | USD | Global Network Rail |
+| Australia | USD | Global Network Rail |
+| Austria | USD | Global Network Rail |
+| Belgium | USD | Global Network Rail |
+| Brazil | USD | Global Network Rail |
+| Bulgaria | USD | Global Network Rail |
+| Canada | USD | Global Network Rail |
+| Chile | USD | Global Network Rail |
+| China | USD | Global Network Rail |
+| Colombia | USD | Global Network Rail |
+| Croatia | USD | Global Network Rail |
+| Cyprus | USD | Global Network Rail |
+| Czech Republic | USD | Global Network Rail |
+| Denmark | USD | Global Network Rail |
+| Estonia | USD | Global Network Rail |
+| Finland | USD | Global Network Rail |
+| France | USD | Global Network Rail |
+| Germany | USD | Global Network Rail |
+| Greece | USD | Global Network Rail |
+| Hong Kong | USD | Global Network Rail |
+| Hungary | USD | Global Network Rail |
+| Iceland | USD | Global Network Rail |
+| Indonesia | USD | Global Network Rail |
+| Ireland | USD | Global Network Rail |
+| Israel | USD | Global Network Rail |
+| Italy | USD | Global Network Rail |
+| Japan | USD | Global Network Rail |
+| Kenya | USD | Global Network Rail |
+| Latvia | USD | Global Network Rail |
+| Liechtenstein | USD | Global Network Rail |
+| Lithuania | USD | Global Network Rail |
+| Luxembourg | USD | Global Network Rail |
+| Malta | USD | Global Network Rail |
+| Mexico | USD | Global Network Rail |
+| Netherlands | USD | Global Network Rail |
+| New Zealand | USD | Global Network Rail |
+| Nigeria | USD | Global Network Rail |
+| Norway | USD | Global Network Rail |
+| Poland | USD | Global Network Rail |
+| Portugal | USD | Global Network Rail |
+| Romania | USD | Global Network Rail |
+| Serbia | USD | Global Network Rail |
+| Singapore | USD | Global Network Rail |
+| Slovakia | USD | Global Network Rail |
+| Slovenia | USD | Global Network Rail |
+| South Africa | USD | Global Network Rail |
+| South Korea | USD | Global Network Rail |
+| Spain | USD | Global Network Rail |
+| Sweden | USD | Global Network Rail |
+| Taiwan | USD | Global Network Rail |
+| Thailand | USD | Global Network Rail |
+| Turkey | USD | Global Network Rail |
+| United Arab Emirates | USD | Global Network Rail |
+| United Kingdom | USD | Global Network Rail |
 
 <Note>
-  USD SWIFT payouts are currently limited to senders based in the United States. For other regions, please use the [Global Network](/rails/global-network) rail.
+  USD SWIFT payouts through the USD Rail are currently limited to senders based in the United States. For other regions, use the [Global Network](/rails/global-network) rail.
 </Note>
 
 - [Learn more about the USD Rail](/rails/usd)
+- [Learn more about the Global Network Rail](/rails/global-network)
 
-## Global Network Rail
+### EUR Payouts
 
-The Global Network Rail supports international payouts in local currencies and USD through SEPA, SWIFT, and local payment networks.
+EUR payouts are delivered through SEPA.
 
-| Country | Currency | Direction | Payment Methods |
-| --- | --- | --- | --- |
-| Albania | EUR | Payout | SEPA |
-| Andorra | EUR | Payout | SEPA |
-| Argentina | USD | Payout | SWIFT |
-| Australia | USD | Payout | SWIFT |
-| Austria | EUR | Payout | SEPA |
-| Austria | USD | Payout | SWIFT |
-| Belgium | EUR | Payout | SEPA |
-| Belgium | USD | Payout | SWIFT |
-| Brazil | BRL | Payout | PIX |
-| Brazil | USD | Payout | SWIFT |
-| Bulgaria | EUR | Payout | SEPA |
-| Bulgaria | USD | Payout | SWIFT |
-| Canada | USD | Payout | SWIFT |
-| Chile | USD | Payout | SWIFT |
-| China | CNY | Payout | SWIFT |
-| China | USD | Payout | SWIFT |
-| Colombia | USD | Payout | SWIFT |
-| Croatia | EUR | Payout | SEPA |
-| Croatia | USD | Payout | SWIFT |
-| Cyprus | EUR | Payout | SEPA |
-| Cyprus | USD | Payout | SWIFT |
-| Czech Republic | EUR | Payout | SEPA |
-| Czech Republic | USD | Payout | SWIFT |
-| Denmark | EUR | Payout | SEPA |
-| Denmark | USD | Payout | SWIFT |
-| Estonia | EUR | Payout | SEPA |
-| Estonia | USD | Payout | SWIFT |
-| Finland | EUR | Payout | SEPA |
-| Finland | USD | Payout | SWIFT |
-| France | EUR | Payout | SEPA |
-| France | USD | Payout | SWIFT |
-| Germany | EUR | Payout | SEPA |
-| Germany | USD | Payout | SWIFT |
-| Greece | EUR | Payout | SEPA |
-| Greece | USD | Payout | SWIFT |
-| Hong Kong | HKD | Payout | SWIFT, CHATS, FPS |
-| Hong Kong | USD | Payout | SWIFT |
-| Hungary | EUR | Payout | SEPA |
-| Hungary | USD | Payout | SWIFT |
-| Iceland | EUR | Payout | SEPA |
-| Iceland | USD | Payout | SWIFT |
-| Indonesia | USD | Payout | SWIFT |
-| Ireland | EUR | Payout | SEPA |
-| Ireland | USD | Payout | SWIFT |
-| Israel | USD | Payout | SWIFT |
-| Italy | EUR | Payout | SEPA |
-| Italy | USD | Payout | SWIFT |
-| Japan | USD | Payout | SWIFT |
-| Kenya | USD | Payout | SWIFT |
-| Latvia | EUR | Payout | SEPA |
-| Latvia | USD | Payout | SWIFT |
-| Liechtenstein | EUR | Payout | SEPA |
-| Liechtenstein | USD | Payout | SWIFT |
-| Lithuania | EUR | Payout | SEPA |
-| Lithuania | USD | Payout | SWIFT |
-| Luxembourg | EUR | Payout | SEPA |
-| Luxembourg | USD | Payout | SWIFT |
-| Malta | EUR | Payout | SEPA |
-| Malta | USD | Payout | SWIFT |
-| Mexico | MXN | Payout | SPEI |
-| Mexico | USD | Payout | SWIFT |
-| Moldova | EUR | Payout | SEPA |
-| Monaco | EUR | Payout | SEPA |
-| Montenegro | EUR | Payout | SEPA |
-| Netherlands | EUR | Payout | SEPA |
-| Netherlands | USD | Payout | SWIFT |
-| New Zealand | USD | Payout | SWIFT |
-| Nigeria | USD | Payout | SWIFT |
-| Nigeria | NGN | Payout | Bank |
-| North Macedonia | EUR | Payout | SEPA |
-| Norway | EUR | Payout | SEPA |
-| Norway | USD | Payout | SWIFT |
-| Poland | EUR | Payout | SEPA |
-| Poland | USD | Payout | SWIFT |
-| Portugal | EUR | Payout | SEPA |
-| Portugal | USD | Payout | SWIFT |
-| Romania | EUR | Payout | SEPA |
-| Romania | USD | Payout | SWIFT |
-| San Marino | EUR | Payout | SEPA |
-| Serbia | EUR | Payout | SEPA |
-| Serbia | USD | Payout | SWIFT |
-| Singapore | SGD | Payout | Local |
-| Singapore | USD | Payout | SWIFT |
-| Slovakia | EUR | Payout | SEPA |
-| Slovakia | USD | Payout | SWIFT |
-| Slovenia | EUR | Payout | SEPA |
-| Slovenia | USD | Payout | SWIFT |
-| South Africa | USD | Payout | SWIFT |
-| South Korea | USD | Payout | SWIFT |
-| Spain | EUR | Payout | SEPA |
-| Spain | USD | Payout | SWIFT |
-| Sweden | EUR | Payout | SEPA |
-| Sweden | USD | Payout | SWIFT |
-| Switzerland | EUR | Payout | SEPA |
-| Taiwan | USD | Payout | SWIFT |
-| Thailand | USD | Payout | SWIFT |
-| Turkey | USD | Payout | SWIFT |
-| United Arab Emirates | USD | Payout | SWIFT |
-| United Kingdom | USD | Payout | SWIFT |
-| Vatican City | EUR | Payout | SEPA |
+| Country | Currency | Payment Methods |
+| --- | --- | --- |
+| Albania | EUR | SEPA |
+| Andorra | EUR | SEPA |
+| Austria | EUR | SEPA |
+| Belgium | EUR | SEPA |
+| Bulgaria | EUR | SEPA |
+| Croatia | EUR | SEPA |
+| Cyprus | EUR | SEPA |
+| Czech Republic | EUR | SEPA |
+| Denmark | EUR | SEPA |
+| Estonia | EUR | SEPA |
+| Finland | EUR | SEPA |
+| France | EUR | SEPA |
+| Germany | EUR | SEPA |
+| Greece | EUR | SEPA |
+| Hungary | EUR | SEPA |
+| Iceland | EUR | SEPA |
+| Ireland | EUR | SEPA |
+| Italy | EUR | SEPA |
+| Latvia | EUR | SEPA |
+| Liechtenstein | EUR | SEPA |
+| Lithuania | EUR | SEPA |
+| Luxembourg | EUR | SEPA |
+| Malta | EUR | SEPA |
+| Moldova | EUR | SEPA |
+| Monaco | EUR | SEPA |
+| Montenegro | EUR | SEPA |
+| Netherlands | EUR | SEPA |
+| North Macedonia | EUR | SEPA |
+| Norway | EUR | SEPA |
+| Poland | EUR | SEPA |
+| Portugal | EUR | SEPA |
+| Romania | EUR | SEPA |
+| San Marino | EUR | SEPA |
+| Serbia | EUR | SEPA |
+| Slovakia | EUR | SEPA |
+| Slovenia | EUR | SEPA |
+| Spain | EUR | SEPA |
+| Sweden | EUR | SEPA |
+| Switzerland | EUR | SEPA |
+| Vatican City | EUR | SEPA |
 
 [Learn more about the Global Network Rail](/rails/global-network)
 
-## Africa Rail (Beta)
+### Local-Currency Payouts
 
-The Africa Rail supports local-currency pay-ins and payouts through bank transfers and mobile money in select African countries.
+| Country | Currency | Payment Methods |
+| --- | --- | --- |
+| Brazil | BRL | PIX |
+| China | CNY | SWIFT |
+| Hong Kong | HKD | SWIFT, CHATS, FPS |
+| Mexico | MXN | SPEI |
+| Nigeria | NGN | Bank |
+| Singapore | SGD | Local |
 
-| Country | Currency | Direction | Payment Methods |
-| --- | --- | --- | --- |
-| Benin | XOF | Payin, Payout | Mobile Money |
-| Botswana | BWP | Payin, Payout | Bank, Mobile Money |
-| Burkina Faso | XOF | Payout | Mobile Money |
-| Cameroon | XAF | Payin, Payout | Mobile Money |
-| Côte d'Ivoire | XOF | Payin, Payout | Mobile Money |
-| Kenya | KES | Payout | Bank, Mobile Money |
-| Malawi | MWK | Payin, Payout | Mobile Money |
-| Mali | XOF | Payout | Mobile Money |
-| Nigeria | NGN | Payin, Payout | Bank Transfer |
-| Senegal | XOF | Payout | Mobile Money |
-| South Africa | ZAR | Payout | Bank |
-| Tanzania | TZS | Payin, Payout | Bank, Mobile Money |
-| Togo | XOF | Payin, Payout | Mobile Money |
-| Uganda | UGX | Payin, Payout | Mobile Money |
-| Zambia | ZMW | Payin, Payout | Mobile Money |
+[Learn more about the Global Network Rail](/rails/global-network)
+
+### Africa Payouts (Beta)
+
+| Country | Currency | Payment Methods |
+| --- | --- | --- |
+| Benin | XOF | Mobile Money |
+| Botswana | BWP | Bank, Mobile Money |
+| Burkina Faso | XOF | Mobile Money |
+| Cameroon | XAF | Mobile Money |
+| Côte d'Ivoire | XOF | Mobile Money |
+| Kenya | KES | Bank, Mobile Money |
+| Malawi | MWK | Mobile Money |
+| Mali | XOF | Mobile Money |
+| Nigeria | NGN | Bank Transfer |
+| Senegal | XOF | Mobile Money |
+| South Africa | ZAR | Bank |
+| Tanzania | TZS | Bank, Mobile Money |
+| Togo | XOF | Mobile Money |
+| Uganda | UGX | Mobile Money |
+| Zambia | ZMW | Mobile Money |
 
 [Learn more about the Africa Rail](/rails/africa)


### PR DESCRIPTION
## What changed

- reorganizes the Coverage page around Payins and Payouts instead of internal rails
- adds stablecoin coverage across available, upon-request, and coming-soon blockchain networks
- groups payout destinations by USD domestic, USD SWIFT, EUR, local currency, and Africa products
- replaces single-country USD tables with payment rail and duration summaries
- retains links and restrictions for the underlying USD, Global Network, and Africa rails

## Why

Customers typically start with the product and payment direction they need, rather than the internal rail that powers it. The new structure makes supported destinations and methods easier to scan.

## Impact

The `/coverage` route and navigation remain unchanged. All 172 existing fiat coverage facts are preserved, and the stablecoin matrix matches all 11 network/currency rows documented on the Wallets page.

## Validation

- `git diff --check`
- semantic comparison against the original coverage tables: 172 facts preserved, 0 missing, 0 added
- stablecoin comparison against the Wallets page: 11 network/currency rows matched, 0 missing, 0 added
- `mintlify broken-links`: no broken links in `coverage.mdx` (pre-existing failures remain in unrelated files)
