### PR TITLE
Update compliance restrictions

### DIFF
--- a/compliance/industries.mdx
+++ b/compliance/industries.mdx
@@ -24,6 +24,10 @@ sidebarTitle: "Industries"
 - Weapons, firearms and ammunition
 - Defense company
 - Bribery or corruption
+- Shell banks and non-resident banks with no physical presence in any jurisdiction
+- Crypto mixers, tumblers, and darknet marketplaces
+- Payday lending and high-cost short-term consumer lending
+- Foreign government entities and diplomatic missions (embassies, consulates, permanent missions)
 
 ### High Scam or Fraud Risks
 
@@ -37,7 +41,6 @@ sidebarTitle: "Industries"
 
 ### Stringent Regulations or High Criminal Abuse Risk
 
-- Art, antiques, precious metal and stones dealers/wholesaler
 - Stocks, bonds and futures
 - Alcohols, Alcoholic beverages
 - Cigarettes, E-cigarettes or non-cigarette tobacco products
@@ -45,7 +48,7 @@ sidebarTitle: "Industries"
 - Prescription drugs and devices
 - Medical Devices (i.e. contact lenses, pacemakers, surgical instruments, etc.)
 - Off-shore banking
-- Virtual currency, currency
+- Unlicensed or unregistered money service businesses and virtual asset service providers (VASPs)
 - Consumer credit reporting agencies
 - Credit repair services
 - Pawn shops

--- a/compliance/regions.mdx
+++ b/compliance/regions.mdx
@@ -13,7 +13,10 @@ sidebarTitle: "Regions"
 - Cuba (CU)
 - Iran (IR)
 - Korea, North (KP)
+- Russia (RU)
 - Syria (SY)
+- Ukraine — Crimea, Donetsk, and Luhansk regions only
+- Venezuela (VE)
 
 ## High Risk Regions
 
@@ -93,7 +96,6 @@ Business users incorporated in some supported countries can be enabled for USD v
 - Pakistan (PK)
 - Palestinian Territories (PS)
 - Peru (PE)
-- Russia (RU)
 - Saint Kitts and Nevis (KN)
 - Senegal (SN)
 - Somalia (SO)
@@ -106,8 +108,6 @@ Business users incorporated in some supported countries can be enabled for USD v
 - Tunisia (TN)
 - Turkey (TR)
 - Turkmenistan (TM)
-- Ukraine (UA)
 - Vanuatu (VU)
-- Venezuela (VE)
 - Yemen (YE)
 - Zimbabwe (ZW)


### PR DESCRIPTION
## Summary

Updates the public compliance documentation to match the recommended jurisdiction and industry restrictions.

## What changed

- Classifies Russia and Venezuela as prohibited regions.
- Limits the Ukraine prohibition to Crimea, Donetsk, and Luhansk, and removes the country-wide unsupported listing.
- Replaces the blanket virtual-currency restriction with a restriction on unlicensed or unregistered MSBs and VASPs.
- Keeps art, antiques, and fine jewelry only in the high-risk section.
- Adds shell banks, crypto mixers and darknet marketplaces, payday lending, and foreign government or diplomatic entities to prohibited activities.

## Impact

The public regions and industries pages now reflect the supplied BSA/AML and sanctions policy recommendations more accurately.

## Validation

- `git diff --check`
- Confirmed all requested additions and removals in the two affected MDX files.
- `mint broken-links` (reports 31 pre-existing broken links in 22 unrelated files; neither changed file is listed).
