### PR TITLE
docs: add virtual account coverage countries

### DIFF
--- a/coverage.mdx
+++ b/coverage.mdx
@@ -51,8 +51,8 @@ description: "HIFI enables inflows and outflows across multiple regions. Here ar
   USD SWIFT payouts are currently limited to senders based in the United States. For other regions, please use the [Global Network](/rails/global-network) rail.
 </Note>
 
-\* Virtual Account pay-in eligibility in starred countries is limited to
-business users and requires enhanced verification, including identity and
+\* Virtual account pay-ins in starred countries are currently limited to
+business users and require enhanced verification, including identity and
 liveness checks for every UBO with at least 10% ownership.
 
 - [Learn more about the USD Rail](/rails/usd)

--- a/coverage.mdx
+++ b/coverage.mdx
@@ -11,6 +11,7 @@ description: "HIFI enables inflows and outflows across multiple regions. Here ar
 | Australia | USD | Payout | SWIFT |
 | Austria | USD | Payout | SWIFT |
 | Belgium | USD | Payout | SWIFT |
+| Bolivia* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
 | Brazil | USD | Payout | SWIFT |
 | Canada | USD | Payout | SWIFT |
 | Colombia | USD | Payout | SWIFT |
@@ -21,7 +22,7 @@ description: "HIFI enables inflows and outflows across multiple regions. Here ar
 | Germany | USD | Payout | SWIFT |
 | Greece | USD | Payout | SWIFT |
 | Guatemala | USD | Payout | SWIFT |
-| India | USD | Payout | SWIFT |
+| India* | USD | Payin, Payout | WIRE, ACH, RTP (Virtual Account), SWIFT (Payout-only) |
 | Ireland | USD | Payout | SWIFT |
 | Italy | USD | Payout | SWIFT |
 | Japan | USD | Payout | SWIFT |
@@ -31,20 +32,28 @@ description: "HIFI enables inflows and outflows across multiple regions. Here ar
 | Mexico | USD | Payout | SWIFT |
 | Netherlands | USD | Payout | SWIFT |
 | New Zealand | USD | Payout | SWIFT |
+| Nigeria* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
 | Norway | USD | Payout | SWIFT |
 | Oman | USD | Payout | SWIFT |
-| Philippines | USD | Payout | SWIFT |
+| Panama* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
+| Philippines* | USD | Payin, Payout | WIRE, ACH, RTP (Virtual Account), SWIFT (Payout-only) |
 | Portugal | USD | Payout | SWIFT |
+| Saudi Arabia* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
 | Slovenia | USD | Payout | SWIFT |
 | Spain | USD | Payout | SWIFT |
 | Sweden | USD | Payout | SWIFT |
 | United Arab Emirates | USD | Payout | SWIFT |
 | United Kingdom | USD | Payout | SWIFT |
 | Uruguay | USD | Payout | SWIFT |
+| Vietnam* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
 
 <Note>
   USD SWIFT payouts are currently limited to senders based in the United States. For other regions, please use the [Global Network](/rails/global-network) rail.
 </Note>
+
+\* Virtual Account pay-in eligibility in starred countries is limited to
+business users and requires enhanced verification, including identity and
+liveness checks for every UBO with at least 10% ownership.
 
 - [Learn more about the USD Rail](/rails/usd)
 


### PR DESCRIPTION
## What changed

- Added the seven business-only Cross River USD Virtual Account countries to the USD Rail coverage table: Bolivia, India, Nigeria, Panama, the Philippines, Saudi Arabia, and Vietnam.
- Marked each country with an asterisk and added a matching eligibility footnote.
- Preserved existing SWIFT payout coverage for India and the Philippines while adding their Virtual Account pay-in capability.

## Why

The coverage table did not reflect the business Virtual Account eligibility encoded in the Cross River country restrictions. The API supports these seven countries for businesses but not individuals, subject to enhanced UBO identity and liveness verification.

## Impact

Developers can now distinguish Virtual Account pay-in availability from general USD payout coverage directly on the coverage page.

## Validation

- Compared the table against `UNSUPPORTED_CRB_COUNTRIES` and `UNSUPPORTED_CRB_BUSINESS_COUNTRIES` in the API repository.
- Ran `git diff --check`.
