### PR TITLE
Revert virtual account coverage countries

### DIFF
--- a/coverage.mdx
+++ b/coverage.mdx
@@ -11,7 +11,6 @@ description: "HIFI enables inflows and outflows across multiple regions. Here ar
 | Australia | USD | Payout | SWIFT |
 | Austria | USD | Payout | SWIFT |
 | Belgium | USD | Payout | SWIFT |
-| Bolivia* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
 | Brazil | USD | Payout | SWIFT |
 | Canada | USD | Payout | SWIFT |
 | Colombia | USD | Payout | SWIFT |
@@ -22,7 +21,7 @@ description: "HIFI enables inflows and outflows across multiple regions. Here ar
 | Germany | USD | Payout | SWIFT |
 | Greece | USD | Payout | SWIFT |
 | Guatemala | USD | Payout | SWIFT |
-| India* | USD | Payin, Payout | WIRE, ACH, RTP (Virtual Account), SWIFT (Payout-only) |
+| India | USD | Payout | SWIFT |
 | Ireland | USD | Payout | SWIFT |
 | Italy | USD | Payout | SWIFT |
 | Japan | USD | Payout | SWIFT |
@@ -32,28 +31,20 @@ description: "HIFI enables inflows and outflows across multiple regions. Here ar
 | Mexico | USD | Payout | SWIFT |
 | Netherlands | USD | Payout | SWIFT |
 | New Zealand | USD | Payout | SWIFT |
-| Nigeria* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
 | Norway | USD | Payout | SWIFT |
 | Oman | USD | Payout | SWIFT |
-| Panama* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
-| Philippines* | USD | Payin, Payout | WIRE, ACH, RTP (Virtual Account), SWIFT (Payout-only) |
+| Philippines | USD | Payout | SWIFT |
 | Portugal | USD | Payout | SWIFT |
-| Saudi Arabia* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
 | Slovenia | USD | Payout | SWIFT |
 | Spain | USD | Payout | SWIFT |
 | Sweden | USD | Payout | SWIFT |
 | United Arab Emirates | USD | Payout | SWIFT |
 | United Kingdom | USD | Payout | SWIFT |
 | Uruguay | USD | Payout | SWIFT |
-| Vietnam* | USD | Payin | WIRE, ACH, RTP (Virtual Account) |
 
 <Note>
   USD SWIFT payouts are currently limited to senders based in the United States. For other regions, please use the [Global Network](/rails/global-network) rail.
 </Note>
-
-\* Virtual account pay-ins in starred countries are currently limited to
-business users and require enhanced verification, including identity and
-liveness checks for every UBO with at least 10% ownership.
 
 - [Learn more about the USD Rail](/rails/usd)
 


### PR DESCRIPTION
## What changed

Reverts commit `78533071cb8ba9359af29d2297463271e980d4da` (`docs: add virtual account coverage countries (#99)`).

This removes the newly documented virtual-account pay-in coverage and restores the previous India and Philippines payout-only entries.

## Why

The referenced coverage update needs to be undone so the public documentation returns to its prior state.

## Impact

The USD rail coverage table no longer advertises the virtual-account pay-in countries introduced by the reverted commit.

## Validation

- Confirmed the revert applies cleanly to the current `main`
- Reviewed the resulting `coverage.mdx` diff
- Working tree is clean
