### PR TITLE
Add AED and COP to Global Network currency support

### DIFF
--- a/rails/global-network.mdx
+++ b/rails/global-network.mdx
@@ -39,7 +39,7 @@ description: "The Global Network Rail enables payouts across multiple regions wi
 | Bulgaria             | USD, EUR | Payout    |
 | Chile                | USD      | Payout    |
 | China                | USD, CNY | Payout    |
-| Colombia             | USD      | Payout    |
+| Colombia             | USD, COP | Payout    |
 | Croatia              | USD, EUR | Payout    |
 | Cyprus               | USD, EUR | Payout    |
 | Czech Republic       | USD, EUR | Payout    |
@@ -85,7 +85,7 @@ description: "The Global Network Rail enables payouts across multiple regions wi
 | Switzerland          | EUR      | Payout    |
 | Taiwan               | USD      | Payout    |
 | Thailand             | USD      | Payout    |
-| United Arab Emirates | USD      | Payout    |
+| United Arab Emirates | USD, AED | Payout    |
 | United Kingdom       | USD      | Payout    |
 | Vatican City         | EUR      | Payout    |
 


### PR DESCRIPTION
United Arab Emirates now shows USD, AED and Colombia shows USD, COP on the Global Network rail currency table.

## 📝 Summary
<!-- Provide a brief summary of the changes introduced in this PR -->


## ✨ What’s New
<!-- Describe what’s been added, updated, or removed -->



## 💡 Why It Matters
<!-- Explain the motivation or problem this PR addresses -->


## 🧪 How Has This Been Tested?
- [ ] Unit tests  
- [ ] Integration tests  
- [ ] Manual testing  

<!-- Add details on testing steps or results if applicable -->


## ✅ Checklist
- [ ] Self-reviewed my changes  
- [ ] Added comments in complex areas  
- [ ] Updated documentation where necessary  
- [ ] No new warnings introduced  
- [ ] All tests pass locally  


## 📸 Screenshots / Demo (if applicable)
<!-- Attach screenshots, GIFs, or recordings here -->


## 🗒️ Notes for Reviewers
N/A
