### PR TITLE
Add India INR payout to Global Network

### DIFF
--- a/rails/global-network.mdx
+++ b/rails/global-network.mdx
@@ -14,6 +14,9 @@ description: "The Global Network Rail enables payouts across multiple regions wi
 | FPS            | Payout    | Real Time         |
 | SPEI           | Payout    | Real Time         |
 | PIX            | Payout    | Real Time         |
+| IMPS           | Payout    | Real Time         |
+| NEFT           | Payout    | Same business day |
+| RTGS           | Payout    | Real Time         |
 | SEPA (< $100k) | Payout    | Instant or minutes |
 | SEPA (> $100k) | Payout    | Next business day |
 | Bank           | Payout    | 1-3 business days |
@@ -24,6 +27,10 @@ description: "The Global Network Rail enables payouts across multiple regions wi
 
 <Info>
   **Bank** here refers to a local payment rail. It is used for SGD payouts to Singapore and NGN payouts to Nigeria.
+</Info>
+
+<Info>
+  **IMPS**, **NEFT**, and **RTGS** are the local Indian payment rails used for INR payouts to India.
 </Info>
 
 ## Currency Support
@@ -52,6 +59,7 @@ description: "The Global Network Rail enables payouts across multiple regions wi
 | Hong Kong            | USD, HKD | Payout    |
 | Hungary              | USD, EUR | Payout    |
 | Iceland              | USD, EUR | Payout    |
+| India                | INR      | Payout    |
 | Indonesia            | USD      | Payout    |
 | Ireland              | USD, EUR | Payout    |
 | Italy                | USD, EUR | Payout    |


### PR DESCRIPTION
India now appears in the Global Network currency table with INR payout support, and IMPS/NEFT/RTGS are listed as supported payment methods.

## 📝 Summary
<!-- Provide a brief summary of the changes introduced in this PR -->


## ✨ What’s New
<!-- Describe what’s been added, updated, or removed -->



## 💡 Why It Matters
<!-- Explain the motivation or problem this PR addresses -->


## 🧪 How Has This Been Tested?
- [ ] Unit tests  
- [ ] Integration tests  
- [ ] Manual testing  

<!-- Add details on testing steps or results if applicable -->


## ✅ Checklist
- [ ] Self-reviewed my changes  
- [ ] Added comments in complex areas  
- [ ] Updated documentation where necessary  
- [ ] No new warnings introduced  
- [ ] All tests pass locally  


## 📸 Screenshots / Demo (if applicable)
<!-- Attach screenshots, GIFs, or recordings here -->


## 🗒️ Notes for Reviewers
N/A
