### PR TITLE
Add India INR payout to Coverage page

### DIFF
--- a/coverage.mdx
+++ b/coverage.mdx
@@ -96,6 +96,7 @@ The Global Network Rail supports international payouts in local currencies and U
 | Hungary | USD | Payout | SWIFT |
 | Iceland | EUR | Payout | SEPA |
 | Iceland | USD | Payout | SWIFT |
+| India | INR | Payout | IMPS, NEFT, RTGS |
 | Indonesia | USD | Payout | SWIFT |
 | Ireland | EUR | Payout | SEPA |
 | Ireland | USD | Payout | SWIFT |


### PR DESCRIPTION
Adds India INR payout via IMPS, NEFT, and RTGS to the Global Network section of the coverage table, matching the Global Network rail page.

## 📝 Summary
<!-- Provide a brief summary of the changes introduced in this PR -->


## ✨ What’s New
<!-- Describe what’s been added, updated, or removed -->



## 💡 Why It Matters
<!-- Explain the motivation or problem this PR addresses -->


## 🧪 How Has This Been Tested?
- [ ] Unit tests  
- [ ] Integration tests  
- [ ] Manual testing  

<!-- Add details on testing steps or results if applicable -->


## ✅ Checklist
- [ ] Self-reviewed my changes  
- [ ] Added comments in complex areas  
- [ ] Updated documentation where necessary  
- [ ] No new warnings introduced  
- [ ] All tests pass locally  


## 📸 Screenshots / Demo (if applicable)
<!-- Attach screenshots, GIFs, or recordings here -->


## 🗒️ Notes for Reviewers
N/A
